### PR TITLE
Switch contents to a Buffer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ function plugin(opts) {
 
   function processFile(file) {
     var key = file.path.replace(file.base, '');
-    var contents = file.contents;
+    var contents = new Buffer(file.contents);
 
     if (isJsonDefinition(file) && utf8(contents)) {
       _.extend(files, createFilesFromJsonDefinition(contents.toString()));


### PR DESCRIPTION
Constantly getting an error that was keeping metalsmith from understanding stream properly.  (this may be related to Node 6) 
fixes: `Error: File.contents can only be a Buffer, a Stream, or null.`
